### PR TITLE
fix: remove unused conversionPalette type

### DIFF
--- a/simplecolor/simplecolors.go
+++ b/simplecolor/simplecolors.go
@@ -11,10 +11,9 @@ import (
 const TotalHexColorspace = 0xffffff + 1
 
 type (
-	SimpleColor       int
-	NamedPalette      map[string]SimpleColor
-	SimplePalette     []SimpleColor
-	conversionPalette []color.Color
+	SimpleColor   int
+	NamedPalette  map[string]SimpleColor
+	SimplePalette []SimpleColor
 )
 
 func (n NamedPalette) Get(name string) SimpleColor {


### PR DESCRIPTION
## Changes
- Removed unused `conversionPalette` type that was flagged by staticcheck (U1000)
- goimports formatting cleanup

## Testing
- `go test -race ./...` passes
- `staticcheck ./...` clean