### PR TITLE
fix(simplecolor): conform RGBA to color.Color interface, fix ToShortHex and Get bounds

### DIFF
--- a/cmd/testprint.go
+++ b/cmd/testprint.go
@@ -13,7 +13,7 @@ func main() {
 	var open []string
 	var close []string
 	for _, c := range colors {
-		red, green, blue, _ := c.RGBA()
+		red, green, blue := c.RGB8()
 		if (float32(red)*0.299 + float32(green)*0.587 + float32(blue)*0.114) > 150.0 {
 			open = append(open, fmt.Sprintf("\u001B[38;2;%d;%d;%dm", 0, 0, 0))
 		} else {

--- a/simplecolor/oklch.go
+++ b/simplecolor/oklch.go
@@ -27,11 +27,11 @@ func linearToSRGB(c float64) float64 {
 
 // ToOKLCH converts a SimpleColor to the OKLCH color space.
 func (c SimpleColor) ToOKLCH() OKLCH {
-	r, g, b, _ := c.RGBA()
+	r8, g8, b8 := c.RGB8()
 	// Normalize to 0-1
-	rf := sRGBToLinear(float64(r) / 255.0)
-	gf := sRGBToLinear(float64(g) / 255.0)
-	bf := sRGBToLinear(float64(b) / 255.0)
+	rf := sRGBToLinear(float64(r8) / 255.0)
+	gf := sRGBToLinear(float64(g8) / 255.0)
+	bf := sRGBToLinear(float64(b8) / 255.0)
 
 	// Linear RGB to LMS (Ottosson)
 	l_ := 0.4122214708*rf + 0.5363325363*gf + 0.0514459929*bf

--- a/simplecolor/oklch_test.go
+++ b/simplecolor/oklch_test.go
@@ -28,8 +28,8 @@ func TestRoundTrip(t *testing.T) {
 		c := FromHexString(tc.hex)
 		oklch := c.ToOKLCH()
 		back := FromOKLCH(oklch.L, oklch.C, oklch.H)
-		r1, g1, b1, _ := c.RGBA()
-		r2, g2, b2, _ := back.RGBA()
+		r1, g1, b1 := c.RGB8()
+		r2, g2, b2 := back.RGB8()
 		if abs(int(r1)-int(r2)) > tc.tolerance || abs(int(g1)-int(g2)) > tc.tolerance || abs(int(b1)-int(b2)) > tc.tolerance {
 			t.Errorf("round-trip failed for %s: got %s (R%d G%d B%d vs R%d G%d B%d)",
 				c.ToHex(), back.ToHex(), r1, g1, b1, r2, g2, b2)

--- a/simplecolor/simplecolors.go
+++ b/simplecolor/simplecolors.go
@@ -20,11 +20,13 @@ func (n NamedPalette) Get(name string) SimpleColor {
 	return n[name]
 }
 
-func (n NamedPalette) Names() (names []string) {
+func (n NamedPalette) Names() []string {
+	names := make([]string, 0, len(n))
 	for k := range n {
 		names = append(names, k)
 	}
-	return
+	sort.Strings(names)
+	return names
 }
 
 func (n NamedPalette) ToSimplePalette() SimplePalette {
@@ -65,7 +67,7 @@ func (s SimplePalette) Join(b SimplePalette) SimplePalette {
 }
 
 func (s SimplePalette) Get(index int) SimpleColor {
-	if index < 0 || index > len(s) {
+	if index < 0 || index >= len(s) {
 		return FromHexString("#66042d")
 	}
 	return s[index]
@@ -83,27 +85,43 @@ func (c SimpleColor) ToHex() string {
 	return "#" + fmt.Sprintf("%06X", c)
 }
 
+// ToShortHex returns a 3-character hex string if possible (e.g. "#F00"),
+// otherwise falls back to the full 6-character hex string.
 func (c SimpleColor) ToShortHex() string {
-	value := c >> 16 & 0xF
-	value += c >> 8 & 0xF
-	value += c & 0xF
-	return "#" + fmt.Sprintf("%06X", value)
+	r := uint32(c) >> 16 & 0xFF
+	g := uint32(c) >> 8 & 0xFF
+	b := uint32(c) & 0xFF
+	// A color can be shortened when each channel's high and low nibbles match
+	if r>>4 == r&0xF && g>>4 == g&0xF && b>>4 == b&0xF {
+		return "#" + fmt.Sprintf("%X%X%X", r&0xF, g&0xF, b&0xF)
+	}
+	return c.ToHex()
 }
 
+// RGBA implements the color.Color interface. Returns pre-multiplied 16-bit
+// values in [0, 0xFFFF] as required by the standard library.
 func (c SimpleColor) RGBA() (r, g, b, a uint32) {
-	return uint32(c) >> 16 & 0xFF, uint32(c) >> 8 & 0xFF, uint32(c) & 0xFF, 0xFF
+	r8 := uint32(c) >> 16 & 0xFF
+	g8 := uint32(c) >> 8 & 0xFF
+	b8 := uint32(c) & 0xFF
+	return r8 | r8<<8, g8 | g8<<8, b8 | b8<<8, 0xFFFF
+}
+
+// RGB8 returns the 8-bit [0, 255] red, green, and blue components.
+func (c SimpleColor) RGB8() (r, g, b uint8) {
+	return uint8(uint32(c) >> 16 & 0xFF), uint8(uint32(c) >> 8 & 0xFF), uint8(uint32(c) & 0xFF)
 }
 
 func (c SimpleColor) ToAnsi16() SimpleColor {
-	color := ansi[0:16].ToPalette().Convert(c)
-	r, g, b, _ := color.RGBA()
-	return SimpleColor(uint32(r)<<16 + uint32(g)<<8 + b)
+	converted := ansi[0:16].ToPalette().Convert(c)
+	r, g, b, _ := converted.RGBA()
+	return SimpleColor((r>>8)<<16 | (g>>8)<<8 | (b >> 8))
 }
 
 func (c SimpleColor) ToExtendedAnsi() SimpleColor {
-	color := ansi.ToPalette().Convert(c)
-	r, g, b, _ := color.RGBA()
-	return SimpleColor(uint32(r)<<16 + uint32(g)<<8 + b)
+	converted := ansi.ToPalette().Convert(c)
+	r, g, b, _ := converted.RGBA()
+	return SimpleColor((r>>8)<<16 | (g>>8)<<8 | (b >> 8))
 }
 
 func (n NamedPalette) ToExtendedAnsi() NamedPalette {
@@ -159,11 +177,10 @@ func New(color int) SimpleColor {
 	return SimpleColor(color % TotalHexColorspace)
 }
 
+// FromRGBA creates a SimpleColor from 8-bit [0, 255] R, G, B values.
+// The alpha component is ignored.
 func FromRGBA(r, g, b, _ uint32) SimpleColor {
-	c := r % TotalHexColorspace
-	c = c<<8 + (g % TotalHexColorspace)
-	c = c<<8 + (b % TotalHexColorspace)
-	return SimpleColor(c)
+	return SimpleColor((r&0xFF)<<16 | (g&0xFF)<<8 | (b & 0xFF))
 }
 
 func FromHexString(h string) SimpleColor {

--- a/simplecolor/simplecolors_test.go
+++ b/simplecolor/simplecolors_test.go
@@ -1,6 +1,7 @@
 package simplecolor
 
 import (
+	"image/color"
 	"testing"
 )
 
@@ -83,5 +84,119 @@ func TestFromHex(t *testing.T) {
 				t.Errorf("Expected Value %s, but got %s", c.Result, color.ToHex())
 			}
 		})
+	}
+}
+
+func TestColorInterface(t *testing.T) {
+	// Verify SimpleColor implements color.Color with proper 16-bit values
+	var _ color.Color = SimpleColor(0)
+
+	red := FromHexString("#FF0000")
+	r, g, b, a := red.RGBA()
+	if r != 0xFFFF {
+		t.Errorf("red R: got %d, want %d", r, 0xFFFF)
+	}
+	if g != 0 {
+		t.Errorf("red G: got %d, want 0", g)
+	}
+	if b != 0 {
+		t.Errorf("red B: got %d, want 0", b)
+	}
+	if a != 0xFFFF {
+		t.Errorf("red A: got %d, want %d", a, 0xFFFF)
+	}
+
+	// Test a mid-value color
+	mid := FromHexString("#808080")
+	mr, mg, mb, _ := mid.RGBA()
+	if mr != 0x8080 || mg != 0x8080 || mb != 0x8080 {
+		t.Errorf("mid RGBA: got (0x%04X, 0x%04X, 0x%04X), want all 0x8080", mr, mg, mb)
+	}
+}
+
+func TestRGB8(t *testing.T) {
+	c := FromHexString("#1A2B3C")
+	r, g, b := c.RGB8()
+	if r != 0x1A || g != 0x2B || b != 0x3C {
+		t.Errorf("RGB8: got (%d, %d, %d), want (26, 43, 60)", r, g, b)
+	}
+}
+
+func TestToShortHex(t *testing.T) {
+	tc := []struct {
+		input string
+		want  string
+	}{
+		{"#FF0000", "#F00"},
+		{"#00FF00", "#0F0"},
+		{"#AABBCC", "#ABC"},
+		{"#000000", "#000"},
+		{"#FFFFFF", "#FFF"},
+		{"#123456", "#123456"}, // cannot be shortened
+		{"#F00000", "#F00000"}, // 0xF0 high!=low nibble
+	}
+	for _, c := range tc {
+		got := FromHexString(c.input).ToShortHex()
+		if got != c.want {
+			t.Errorf("ToShortHex(%s): got %s, want %s", c.input, got, c.want)
+		}
+	}
+}
+
+func TestGetBounds(t *testing.T) {
+	p := SimplePalette{FromHexString("#FF0000"), FromHexString("#00FF00")}
+	// Valid indices
+	if p.Get(0).ToHex() != "#FF0000" {
+		t.Error("Get(0) failed")
+	}
+	if p.Get(1).ToHex() != "#00FF00" {
+		t.Error("Get(1) failed")
+	}
+	// Out of bounds should return fallback
+	fallback := FromHexString("#66042d").ToHex()
+	if p.Get(-1).ToHex() != fallback {
+		t.Error("Get(-1) should return fallback")
+	}
+	if p.Get(2).ToHex() != fallback {
+		t.Error("Get(len) should return fallback")
+	}
+}
+
+func TestNamedPaletteNamesSorted(t *testing.T) {
+	np := NamedPalette{
+		"zebra":    FromHexString("#000000"),
+		"apple":    FromHexString("#FF0000"),
+		"mango":    FromHexString("#FFAA00"),
+		"bluebird": FromHexString("#0000FF"),
+	}
+	names := np.Names()
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("Names() not sorted: %v", names)
+			break
+		}
+	}
+}
+
+func TestPaletteConvert(t *testing.T) {
+	// color.Palette.Convert uses Euclidean distance in the RGBA space.
+	// With proper 16-bit RGBA, this should find the nearest color correctly.
+	p := SimplePalette{
+		FromHexString("#000000"),
+		FromHexString("#FFFFFF"),
+	}.ToPalette()
+
+	// A dark color should map to black
+	nearest := p.Convert(FromHexString("#111111"))
+	r, _, _, _ := nearest.RGBA()
+	if r != 0 {
+		t.Errorf("expected dark color to map to black, got R=%d", r)
+	}
+
+	// A light color should map to white
+	nearest = p.Convert(FromHexString("#EEEEEE"))
+	rW, _, _, _ := nearest.RGBA()
+	if rW != 0xFFFF {
+		t.Errorf("expected light color to map to white, got R=%d", rW)
 	}
 }


### PR DESCRIPTION
## Changes

### RGBA() now conforms to `color.Color` interface
`RGBA()` was returning 8-bit values in `[0, 255]` instead of the 16-bit pre-multiplied values in `[0, 0xFFFF]` required by Go's `color.Color` interface. This meant `color.Palette.Convert()` and any standard library color operations were getting incorrect distance calculations.

Added `RGB8()` method for convenient 8-bit access (replaces the old `RGBA()` use case).

### ToShortHex() was completely broken
The old implementation shifted and added individual nibbles — it didn't actually produce a valid short hex string. Now correctly checks if each channel's high and low nibbles match (e.g. `#FF0000` → `#F00`, `#123456` stays full).

### Other fixes
- `SimplePalette.Get()`: off-by-one — `index == len(s)` would panic instead of returning fallback
- `NamedPalette.Names()`: now returns sorted names for deterministic iteration
- `FromRGBA()`: uses bitmask instead of modulo (clearer, correct for all inputs)
- `ToAnsi16()`/`ToExtendedAnsi()`: fixed to downscale 16-bit RGBA back to 8-bit for SimpleColor construction
- `ToOKLCH()`: updated to use `RGB8()` for correct normalization
- `cmd/testprint.go`: updated to use `RGB8()`

### Tests added
- `color.Color` interface compliance
- `ToShortHex` with shortable and non-shortable inputs
- `Get` boundary conditions
- `Names` sort verification
- `Palette.Convert` nearest-color matching

**Breaking change:** `RGBA()` now returns 16-bit values. Code that assumed 8-bit returns should switch to `RGB8()`.