### PR TITLE
fix(simplecolor): normalize negative color values

### DIFF
--- a/simplecolor/simplecolors.go
+++ b/simplecolor/simplecolors.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const TotalHexColorspace = 0xffffff + 1
+const (
+	TotalHexColorspace = 0xffffff + 1
+	fallbackHex        = "#66042d"
+)
 
 type (
 	SimpleColor   int
@@ -68,7 +71,7 @@ func (s SimplePalette) Join(b SimplePalette) SimplePalette {
 
 func (s SimplePalette) Get(index int) SimpleColor {
 	if index < 0 || index >= len(s) {
-		return FromHexString("#66042d")
+		return FromHexString(fallbackHex)
 	}
 	return s[index]
 }
@@ -174,7 +177,11 @@ func (s SimplePalette) ToAnsi16() (sp SimplePalette) {
 }
 
 func New(color int) SimpleColor {
-	return SimpleColor(color % TotalHexColorspace)
+	normalizedColor := color % TotalHexColorspace
+	if normalizedColor < 0 {
+		normalizedColor += TotalHexColorspace
+	}
+	return SimpleColor(normalizedColor)
 }
 
 // FromRGBA creates a SimpleColor from 8-bit [0, 255] R, G, B values.
@@ -199,7 +206,7 @@ func FromHexString(h string) SimpleColor {
 			string(hexRunes[2]))
 		h = stretchedHex
 	default:
-		return FromHexString("#66042d")
+		return FromHexString(fallbackHex)
 	}
 	i, err := strconv.ParseInt(h, 16, 64)
 	if err != nil {
@@ -208,7 +215,7 @@ func FromHexString(h string) SimpleColor {
 		// Instead, return a really weird color to draw attention.
 		// Black is the zero-value and it's actually used often, "plum" is
 		// (probably) not.
-		return FromHexString("#66042d")
+		return FromHexString(fallbackHex)
 	}
 	return SimpleColor(i)
 }

--- a/simplecolor/simplecolors_test.go
+++ b/simplecolor/simplecolors_test.go
@@ -13,6 +13,8 @@ func TestCreateColor(t *testing.T) {
 	}{
 		{ID: "white", Value: TotalHexColorspace - 1, Result: TotalHexColorspace - 1},
 		{ID: "WraparoundBlack", Value: TotalHexColorspace, Result: 0},
+		{ID: "WraparoundWhiteFromNegativeOne", Value: -1, Result: TotalHexColorspace - 1},
+		{ID: "WraparoundWhiteFromNegativeColorspace", Value: -TotalHexColorspace - 1, Result: TotalHexColorspace - 1},
 		{ID: "black", Value: 0, Result: 0},
 	}
 	for _, c := range tc {


### PR DESCRIPTION
## Summary
- Normalize negative inputs in `simplecolor.New` so they wrap into the 24-bit color space instead of producing negative `SimpleColor` values.
- Add regression coverage for negative wraparound boundaries.
- Replace repeated fallback hex literals with one internal constant.

## Validation
- `go generate ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`
